### PR TITLE
prevent webpack from resolving packages symlinks in case of custom-re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## [2.0.3-dev.2] - 2019-02-21
+
+- resolve symlink packages as packages when custom-resolve-modules is used
+
 ## [2.0.3-dev.1] - 2019-02-11
 
 - fix resolve dependencies cache to include parsing errors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-javascript",
-  "version": "2.0.3-dev.1",
+  "version": "2.0.3-dev.2",
   "scripts": {
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "eslint src && flow check || true",

--- a/src/dependency-builder/filing-cabinet/index.js
+++ b/src/dependency-builder/filing-cabinet/index.js
@@ -281,6 +281,9 @@ function resolveNonRelativePath(partial, filename, directory, resolveConfig) {
   if (resolveConfig.modulesDirectories) webpackResolveConfig.modules = resolveConfig.modulesDirectories;
   if (resolveConfig.aliases) webpackResolveConfig.alias = resolveConfig.aliases;
   webpackResolveConfig.extensions = resolveExtensions;
+  // a resolve module might point to an imported component via the package name, in which case
+  // the package name is a symlink to the imported component. we want it to be resolved as a pkg
+  webpackResolveConfig.symlinks = false;
   return resolveWebpack(partial, filename, directory, webpackResolveConfig);
 }
 


### PR DESCRIPTION
…solve-modules. we do need them to stay with the package name so then dependency-tree will filter them as packages and not try to resolve their dependencies

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit-javascript/91)
<!-- Reviewable:end -->
