### PR TITLE
fix resolve-modules prefix with tilda to resolve according to the resolve-modules configuration and fallback to resolve from node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## [2.0.9] - 2019-05-31
+
 - [#1665](https://github.com/teambit/bit/issues/1665) fix resolve-modules prefix with tilda
 
 ## [2.0.8] - 2019-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#1665](https://github.com/teambit/bit/issues/1665) fix resolve-modules prefix with tilda
+
 ## [2.0.8] - 2019-05-27
 
 - add support with `optionalChaining` and `nullishCoalescingOperator` plugins (by updating node-source-walk)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-javascript",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "scripts": {
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "eslint src && flow check || true",

--- a/src/dependency-builder/filing-cabinet/index.js
+++ b/src/dependency-builder/filing-cabinet/index.js
@@ -223,16 +223,15 @@ function jsLookup(options: Options) {
  */
 function cssPreprocessorLookup(options: Options) {
   const { filename, partial, directory, resolveConfig } = options;
-
+  if (resolveConfig && !isRelativeImport(partial)) {
+    const result = resolveNonRelativePath(partial, filename, directory, resolveConfig);
+    if (result) return result;
+  }
   if (partial.startsWith('~') && !partial.startsWith('~/')) {
     // webpack syntax for resolving a module from node_modules
     debug('changing the resolver of css preprocessor to resolveWebpackPath as it has a ~ prefix');
     const partialWithNoTilda = partial.replace('~', '');
     return resolveWebpack(partialWithNoTilda, filename, directory, { extensions: styleExtensions, symlinks: false });
-  }
-  if (resolveConfig && !isRelativeImport(partial)) {
-    const result = resolveNonRelativePath(partial, filename, directory, resolveConfig);
-    if (result) return result;
   }
 
   // Less and Sass imports are very similar

--- a/src/dependency-builder/filing-cabinet/index.spec.js
+++ b/src/dependency-builder/filing-cabinet/index.spec.js
@@ -558,6 +558,34 @@ describe('filing-cabinet', () => {
       assert.equal(result, path.resolve(`${fixtures}/node_modules/bootstrap/index.scss`));
     });
   });
+  describe('.scss with a dependency prefix with a tilda and resolve config', () => {
+    describe('when the alias in resolve-config is resolved to an existing file', () => {
+      it('should resolve the dependency according to the resolve-config', () => {
+        const resolveConfig = { aliases: { '~bootstrap': path.normalize(fixtures) } };
+        const result = cabinet({
+          resolveConfig,
+          partial: '~bootstrap/foo2',
+          filename: `${fixtures}/foo.scss`,
+          directory: fixtures
+        });
+
+        assert.equal(result, path.resolve(`${fixtures}/foo2.scss`));
+      });
+    });
+    describe('when the alias in resolve-config does not match the partial', () => {
+      it('should fallback to the node-module resolution', () => {
+        const resolveConfig = { aliases: { '~non-exist': 'some-dir' } };
+        const result = cabinet({
+          resolveConfig,
+          partial: '~bootstrap/index',
+          filename: `${fixtures}/foo.scss`,
+          directory: fixtures
+        });
+
+        assert.equal(result, path.resolve(`${fixtures}/node_modules/bootstrap/index.scss`));
+      });
+    });
+  });
 
   // @todo: fix.
   describe.skip('webpack', () => {


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/issues/1665

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit-javascript/100)
<!-- Reviewable:end -->
