### PR TITLE
fix dependency resolution of `.` and `..` to not be identified as custom-resolved used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## [2.0.12-angular.3] - 2019-06-14
+
 - fix dependency resolution of `.` and `..` to not be identified as custom-resolved used.
 
 ## [2.0.12-angular.2] - 2019-06-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix dependency resolution of `.` and `..` to not be identified as custom-resolved used.
+
 ## [2.0.12-angular.2] - 2019-06-10
 
 - add rxjs package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-javascript",
-  "version": "2.0.12-angular.2",
+  "version": "2.0.12-angular.3",
   "scripts": {
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "eslint src && flow check || true",

--- a/src/dependency-builder/dependency-tree/index.js
+++ b/src/dependency-builder/dependency-tree/index.js
@@ -139,9 +139,7 @@ module.exports._getDependencies = function (config) {
     if (!isDependenciesArray && dependenciesRaw[dependency].importSpecifiers) {
       pathMap.importSpecifiers = dependenciesRaw[dependency].importSpecifiers;
     }
-    if (!isRelativeImport(dependency) && config.resolveConfig) {
-      // is includes also packages, which actually don't use customResolve, however, they will be
-      // filtered out later.
+    if (cabinetParams.wasCustomResolveUsed) {
       pathMap.isCustomResolveUsed = true;
     }
 

--- a/src/dependency-builder/lookups/vue-lookup/index.js
+++ b/src/dependency-builder/lookups/vue-lookup/index.js
@@ -10,7 +10,7 @@ const languageMap = {
   stylus: 'styl'
 };
 module.exports = function (options) {
-  const { partial, filename, isScript } = options;
+  const { partial, filename, isScript, resolveConfig } = options;
   const cabinet = require('../../filing-cabinet');
 
   const fileContent = fs.readFileSync(filename);
@@ -21,6 +21,7 @@ module.exports = function (options) {
       Object.assign(options, {
         directory: path.dirname(filename),
         content: script.content,
+        ast: null,
         ext: `.${scriptExt}` || path.extname(partial)
       })
     );
@@ -32,6 +33,7 @@ module.exports = function (options) {
         filename: `${path.join(path.dirname(filename), path.parse(filename).name)}.${styleExt}`,
         directory: path.dirname(filename),
         content: style.content,
+        ast: null,
         ext: `.${styleExt}`
       })
     );

--- a/src/dependency-builder/lookups/vue-lookup/index.js
+++ b/src/dependency-builder/lookups/vue-lookup/index.js
@@ -10,32 +10,31 @@ const languageMap = {
   stylus: 'styl'
 };
 module.exports = function (options) {
-  const { partial, filename, isScript, resolveConfig } = options;
+  const { partial, filename, isScript } = options;
   const cabinet = require('../../filing-cabinet');
 
   const fileContent = fs.readFileSync(filename);
   const { script, styles } = compiler.parseComponent(fileContent.toString(), { pad: 'line' });
   if (isScript) {
     const scriptExt = script.lang ? languageMap[script.lang] || script.lang : DEFAULT_SCRIPT_LANG;
-    return cabinet({
-      partial,
-      filename,
-      directory: path.dirname(filename),
-      content: script.content,
-      resolveConfig,
-      ext: `.${scriptExt}` || path.extname(partial)
-    });
+    return cabinet(
+      Object.assign(options, {
+        directory: path.dirname(filename),
+        content: script.content,
+        ext: `.${scriptExt}` || path.extname(partial)
+      })
+    );
   }
   const stylesResult = styles.map((style) => {
     const styleExt = style.lang ? languageMap[style.lang] || style.lang : DEFAULT_STYLE_LANG;
-    return cabinet({
-      partial,
-      filename: `${path.join(path.dirname(filename), path.parse(filename).name)}.${styleExt}`,
-      directory: path.dirname(filename),
-      content: style.content,
-      resolveConfig,
-      ext: `.${styleExt}`
-    });
+    return cabinet(
+      Object.assign(options, {
+        filename: `${path.join(path.dirname(filename), path.parse(filename).name)}.${styleExt}`,
+        directory: path.dirname(filename),
+        content: style.content,
+        ext: `.${styleExt}`
+      })
+    );
   });
   return stylesResult[0];
 };

--- a/src/utils/is-relative-import.js
+++ b/src/utils/is-relative-import.js
@@ -11,5 +11,5 @@
  * End quote.
  */
 export default function isRelativeImport(str: string): boolean {
-  return str.startsWith('./') || str.startsWith('../') || str.startsWith('/');
+  return str.startsWith('./') || str.startsWith('../') || str.startsWith('/') || str === '.' || str === '..';
 }


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/issues/1734 by the following:
1) when the dependency is `.` or `..`, do not try to resolve it with the custom-module-resolution.
2) do not let dependency-tree guess when custom-resolve was used by filing-cabinet. Instead, the filing-cabinet declares once custom-module-resolution was used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit-javascript/105)
<!-- Reviewable:end -->
