### PR TITLE
avoid recognizing any require/import starts with "." as a custom-resolve-module on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- avoid recognizing any require/import starts with `.` as a custom-resolve-module on Windows
+
 ## [2.1.1-dev.2] - 2019-08-13
 
 - [#1925](https://github.com/teambit/bit/issues/1925) fix Angular non-relative paths from decorators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## [2.1.1-dev.3] - 2019-09-20
+
 - avoid recognizing any require/import starts with `.` as a custom-resolve-module on Windows
 
 ## [2.1.1-dev.2] - 2019-08-13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-javascript",
-  "version": "2.1.1-dev.2",
+  "version": "2.1.1-dev.3",
   "scripts": {
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "eslint src && flow check || true",

--- a/src/dependency-builder/filing-cabinet/index.js
+++ b/src/dependency-builder/filing-cabinet/index.js
@@ -294,12 +294,7 @@ function commonJSLookup(options: Options) {
 
   appModulePath.addPath(moduleLookupDir);
 
-  // Make sure the partial is being resolved to the filename's context
-  // 3rd party modules will not be relative
   let partial = options.partial;
-  if (partial[0] === '.') {
-    partial = path.resolve(path.dirname(filename), partial);
-  }
 
   let result = '';
 
@@ -312,6 +307,12 @@ function commonJSLookup(options: Options) {
       return result;
     }
     debug('failed resolved using resolveConfig, fall back to the standard resolver');
+  }
+
+  // Make sure the partial is being resolved to the filename's context
+  // 3rd party modules will not be relative
+  if (partial[0] === '.') {
+    partial = path.resolve(path.dirname(filename), partial);
   }
 
   try {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit-javascript/114)
<!-- Reviewable:end -->
